### PR TITLE
Allow caller to supply their own session object.

### DIFF
--- a/pyperi/pyperi.py
+++ b/pyperi/pyperi.py
@@ -121,7 +121,7 @@ class Peri(object):
             'broadcastHistory', 'serviceToken', 'thumbnailPlaylist'
         ]
 
-        out = {'user_id': data_store['Tracking']['userId']}
+        out = {'user_id': data_store['UserCache']['usernames'][username.lower()]}
         for token_name in token_names:
             out[token_name] = public_tokens[token_name]['token']['session_id']
 

--- a/pyperi/pyperi.py
+++ b/pyperi/pyperi.py
@@ -17,6 +17,14 @@ class Peri(object):
     PERISCOPE_API_BASE_URL = 'https://api.periscope.tv/api/v2'
     PERISCOPE_WEB_BASE_URL = 'https://www.periscope.tv'
 
+    def __init__(self, session=None):
+        """
+        Constructor.  If a `session` is passed, it will be used to retrieve
+        URLs.  This should be a `requests.Session` object, or something like it.
+        If no `session` is passed, one will be created for you.
+        """
+        self.session = session if session else requests.Session()
+
     def request_api(self, endpoint, **params):
         """
         Make a request against the Periscope API and return the result.
@@ -27,7 +35,7 @@ class Peri(object):
         url = self._create_api_request_url(endpoint, **params)
 
         try:
-            r = requests.get(url)
+            r = self.session.get(url)
         except requests.exceptions.ConnectionError as e:
             raise PyPeriConnectionError(e)
 
@@ -186,7 +194,7 @@ class Peri(object):
         return None.
         """
         try:
-            r = requests.get(url)
+            r = self.session.get(url)
         except requests.exceptions.ConnectionError as e:
             raise PyPeriConnectionError(e)
 


### PR DESCRIPTION
* Add a constructor to the Peri() object that takes a `session`
  parameter.  If supplied, this session object will be used instead of
  creating a new one.  My use case is for HTTP proxy support, but
  presumably the caller could change the user agent in some other way if
  they wanted to.  If no session param is supplied, one is created, as
  before.

This PR also includes a fix to the username parsing bug from @gavvvr -- I should have probably kept that separate.  I can back it out and re-submit if necessary.